### PR TITLE
Changes for precedents legfragment and treaties code updation

### DIFF
--- a/COMMON/nonamespace/blockquote.xsl
+++ b/COMMON/nonamespace/blockquote.xsl
@@ -9,6 +9,7 @@
             <xsl:when test="self::blockquote/child::*[1][name()='l'] and $selectorID = 'dictionary'">
                 <xsl:apply-templates select="@* | node()"/>
             </xsl:when>
+            <!-- Revathi: 26May2018 - As suggested by Amita - Commented the below code as it is creating issues in rocket conversion. -->
             <!--<!-\-Dayanand singh 2018-05-02 updated in below when condition of parent::case:factsummary -\->
             <xsl:when test="self::blockquote[ancestor::case:appendix|parent::case:factsummary]/p/text/matches(text()[1],'^\(([a-z]+|[ivx]+)\)')[$selectorID = 'cases']">
                 <xsl:apply-templates/>

--- a/COMMON/nonamespace/heading.xsl
+++ b/COMMON/nonamespace/heading.xsl
@@ -7,7 +7,9 @@
     
     <xsl:template match="heading">
         <xsl:choose>
-            <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">
+            <!-- Revathi: 30May2018 - Changed as per the clarification got from Awntika as legfragment element is not handled in rocket xslt, need to drop this change for precedents. -->
+            <!--<xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">-->
+            <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('treatises','commentaryleghist')]">
                 <leg:heading xsl:exclude-result-prefixes="#all">
                     <xsl:apply-templates select="@* | node()"/>
                 </leg:heading>

--- a/COMMON/nonamespace/title.xsl
+++ b/COMMON/nonamespace/title.xsl
@@ -99,8 +99,13 @@
                             </xsl:otherwise>
                         </xsl:choose>-->
                                 <!-- Revathi: Commented the above code and added the below to normalise the value -->
+                                <!-- Revathi: 29May2018 - (FOR 0PV8) Added the below variable to capture the desig content as the direct passing of parameter to the template "Normalize_id_string" was creating conflicts. -->
+                                <xsl:variable name="v_desig" as="xs:string">
+                                    <xsl:value-of select="self::title/emph/emph[1]//text()"/>
+                                </xsl:variable>
                                 <xsl:call-template name="Normalize_id_string">
-                                    <xsl:with-param name="string" select="self::title/emph/emph[1]//text()"/>
+                                    <!--<xsl:with-param name="string" select="self::title/emph[1]//text()"/>-->
+                                    <xsl:with-param name="string" select="$v_desig"/>
                                 </xsl:call-template>
                             </xsl:attribute>		
                             <designum xsl:exclude-result-prefixes="#all">

--- a/DRIVER/LL-CASES-LAWREPORT-to-LA-CASES-LAWREPORT.xsl
+++ b/DRIVER/LL-CASES-LAWREPORT-to-LA-CASES-LAWREPORT.xsl
@@ -2,7 +2,7 @@
 <!--  ***This XSLT conversion file is a stand-alone, generated release created from a module based source code.  Any changes to this conversion must be propagated to its original source. ***
 This file is not intended to be edited directly, except in a time critical situation such as a  "sev1" webstar.
 Please contact Content Architecture for support and for ensuring the source code is updated as needed and a new stand-alone delivery is released.
-Compiled:  2018-05-29T18:31:28.147+05:30-->
+Compiled:  2018-05-30T13:10:40.514+05:30-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:lnvxe="http://www.lexis-nexis.com/lnvxe"
@@ -979,8 +979,8 @@ Compiled:  2018-05-29T18:31:28.147+05:30-->
    </xsl:template>
 
    <xsl:template match="heading">
-      <xsl:choose>
-         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">
+      <xsl:choose><!-- Revathi: 30May2018 - Changed as per the clarification got from Awntika as legfragment element is not handled in rocket xslt, need to drop this change for precedents. --><!--<xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">-->
+         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('treatises','commentaryleghist')]">
             <leg:heading xsl:exclude-result-prefixes="#all">
                <xsl:apply-templates select="@* | node()"/>
             </leg:heading>
@@ -1074,9 +1074,12 @@ Compiled:  2018-05-29T18:31:28.147+05:30-->
                             <xsl:otherwise>
                                 <xsl:value-of select="self::title/emph/emph[1]//text()"/>
                             </xsl:otherwise>
-                        </xsl:choose>--><!-- Revathi: Commented the above code and added the below to normalise the value -->
-                        <xsl:call-template name="Normalize_id_string">
-                           <xsl:with-param name="string" select="self::title/emph/emph[1]//text()"/>
+                        </xsl:choose>--><!-- Revathi: Commented the above code and added the below to normalise the value --><!-- Revathi: 29May2018 - (FOR 0PV8) Added the below variable to capture the desig content as the direct passing of parameter to the template "Normalize_id_string" was creating conflicts. -->
+                        <xsl:variable name="v_desig" as="xs:string">
+                           <xsl:value-of select="self::title/emph/emph[1]//text()"/>
+                        </xsl:variable>
+                        <xsl:call-template name="Normalize_id_string"><!--<xsl:with-param name="string" select="self::title/emph[1]//text()"/>-->
+                           <xsl:with-param name="string" select="$v_desig"/>
                         </xsl:call-template>
                      </xsl:attribute>
                      <designum xsl:exclude-result-prefixes="#all">
@@ -1867,6 +1870,7 @@ Compiled:  2018-05-29T18:31:28.147+05:30-->
          <xsl:when test="self::blockquote/child::*[1][name()='l'] and $selectorID = 'dictionary'">
             <xsl:apply-templates select="@* | node()"/>
          </xsl:when>
+         <!-- Revathi: 26May2018 - As suggested by Amita - Commented the below code as it is creating issues in rocket conversion. -->
          <!--<!-\-Dayanand singh 2018-05-02 updated in below when condition of parent::case:factsummary -\->
             <xsl:when test="self::blockquote[ancestor::case:appendix|parent::case:factsummary]/p/text/matches(text()[1],'^\(([a-z]+|[ivx]+)\)')[$selectorID = 'cases']">
                 <xsl:apply-templates/>

--- a/DRIVER/LL-PRECEDENTS-to-LA-PRECEDENTS.xsl
+++ b/DRIVER/LL-PRECEDENTS-to-LA-PRECEDENTS.xsl
@@ -2,7 +2,7 @@
 <!--  ***This XSLT conversion file is a stand-alone, generated release created from a module based source code.  Any changes to this conversion must be propagated to its original source. ***
 This file is not intended to be edited directly, except in a time critical situation such as a  "sev1" webstar.
 Please contact Content Architecture for support and for ensuring the source code is updated as needed and a new stand-alone delivery is released.
-Compiled:  2018-05-30T11:05:18.746+05:30-->
+Compiled:  2018-05-30T13:10:50.097+05:30-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:lnvxe="http://www.lexis-nexis.com/lnvxe"
@@ -76,8 +76,8 @@ Compiled:  2018-05-30T11:05:18.746+05:30-->
          <xsl:value-of select="self::level/@leveltype"/>
       </xsl:variable>
       <!-- Revathi: Whenever the level is having heading/@searchtype as LEGISLATION, then we need to create level/bodytext/leg:level/leg:level-vrnt corresponding to the level in the input -->
-      <xsl:choose>
-         <xsl:when test="self::level/heading/@searchtype='LEGISLATION'">
+      <xsl:choose><!-- Revathi: 30May2018 - Changed as per the clarification got from Awntika as legfragment element is not handled in rocket xslt, need to drop this change for precedents. -->
+         <xsl:when test="self::level/heading/@searchtype='LEGISLATION' and not($selectorID = 'precedents')">
             <xsl:choose><!-- Revathi: To check whether there are any ancestor level with @searchtype='LEGISLATION'.
                     If present, then should create leg:level/leg:level-vrnt only corresponding to the level in the input-->
                <xsl:when test="not(ancestor::level/child::heading/@searchtype='LEGISLATION')">
@@ -128,7 +128,7 @@ Compiled:  2018-05-30T11:05:18.746+05:30-->
 
    <xsl:template match="bodytext[parent::level][$selectorID=('precedents','treatises','commentaryleghist')]">
       <xsl:choose>
-         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]"><!-- Revathi: Commented the below tags as this handling has been moved to precedents_level_Chof_comm.body.xsl to avoid validation errors --><!--<leg:levelbody xsl:exclude-result-prefixes="#all">
+         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('treatises','commentaryleghist')]"><!-- Revathi: Commented the below tags as this handling has been moved to precedents_level_Chof_comm.body.xsl to avoid validation errors --><!--<leg:levelbody xsl:exclude-result-prefixes="#all">
                     <leg:bodytext xsl:exclude-result-prefixes="#all">-->
             <xsl:apply-templates select="@* | node()"/>
             <!--</leg:bodytext>
@@ -592,8 +592,8 @@ Compiled:  2018-05-30T11:05:18.746+05:30-->
    </xsl:template>
 
    <xsl:template match="heading">
-      <xsl:choose>
-         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">
+      <xsl:choose><!-- Revathi: 30May2018 - Changed as per the clarification got from Awntika as legfragment element is not handled in rocket xslt, need to drop this change for precedents. --><!--<xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">-->
+         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('treatises','commentaryleghist')]">
             <leg:heading xsl:exclude-result-prefixes="#all">
                <xsl:apply-templates select="@* | node()"/>
             </leg:heading>
@@ -687,9 +687,12 @@ Compiled:  2018-05-30T11:05:18.746+05:30-->
                             <xsl:otherwise>
                                 <xsl:value-of select="self::title/emph/emph[1]//text()"/>
                             </xsl:otherwise>
-                        </xsl:choose>--><!-- Revathi: Commented the above code and added the below to normalise the value -->
-                        <xsl:call-template name="Normalize_id_string">
-                           <xsl:with-param name="string" select="self::title/emph/emph[1]//text()"/>
+                        </xsl:choose>--><!-- Revathi: Commented the above code and added the below to normalise the value --><!-- Revathi: 29May2018 - (FOR 0PV8) Added the below variable to capture the desig content as the direct passing of parameter to the template "Normalize_id_string" was creating conflicts. -->
+                        <xsl:variable name="v_desig" as="xs:string">
+                           <xsl:value-of select="self::title/emph/emph[1]//text()"/>
+                        </xsl:variable>
+                        <xsl:call-template name="Normalize_id_string"><!--<xsl:with-param name="string" select="self::title/emph[1]//text()"/>-->
+                           <xsl:with-param name="string" select="$v_desig"/>
                         </xsl:call-template>
                      </xsl:attribute>
                      <designum xsl:exclude-result-prefixes="#all">
@@ -1480,6 +1483,7 @@ Compiled:  2018-05-30T11:05:18.746+05:30-->
          <xsl:when test="self::blockquote/child::*[1][name()='l'] and $selectorID = 'dictionary'">
             <xsl:apply-templates select="@* | node()"/>
          </xsl:when>
+         <!-- Revathi: 26May2018 - As suggested by Amita - Commented the below code as it is creating issues in rocket conversion. -->
          <!--<!-\-Dayanand singh 2018-05-02 updated in below when condition of parent::case:factsummary -\->
             <xsl:when test="self::blockquote[ancestor::case:appendix|parent::case:factsummary]/p/text/matches(text()[1],'^\(([a-z]+|[ivx]+)\)')[$selectorID = 'cases']">
                 <xsl:apply-templates/>

--- a/DRIVER/LL-TREATISES-to-LA-TREATISES.xsl
+++ b/DRIVER/LL-TREATISES-to-LA-TREATISES.xsl
@@ -2,7 +2,7 @@
 <!--  ***This XSLT conversion file is a stand-alone, generated release created from a module based source code.  Any changes to this conversion must be propagated to its original source. ***
 This file is not intended to be edited directly, except in a time critical situation such as a  "sev1" webstar.
 Please contact Content Architecture for support and for ensuring the source code is updated as needed and a new stand-alone delivery is released.
-Compiled:  2018-05-30T11:05:21.08+05:30-->
+Compiled:  2018-05-30T13:10:52.851+05:30-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:lnvxe="http://www.lexis-nexis.com/lnvxe"
@@ -76,8 +76,8 @@ Compiled:  2018-05-30T11:05:21.08+05:30-->
          <xsl:value-of select="self::level/@leveltype"/>
       </xsl:variable>
       <!-- Revathi: Whenever the level is having heading/@searchtype as LEGISLATION, then we need to create level/bodytext/leg:level/leg:level-vrnt corresponding to the level in the input -->
-      <xsl:choose>
-         <xsl:when test="self::level/heading/@searchtype='LEGISLATION'">
+      <xsl:choose><!-- Revathi: 30May2018 - Changed as per the clarification got from Awntika as legfragment element is not handled in rocket xslt, need to drop this change for precedents. -->
+         <xsl:when test="self::level/heading/@searchtype='LEGISLATION' and not($selectorID = 'precedents')">
             <xsl:choose><!-- Revathi: To check whether there are any ancestor level with @searchtype='LEGISLATION'.
                     If present, then should create leg:level/leg:level-vrnt only corresponding to the level in the input-->
                <xsl:when test="not(ancestor::level/child::heading/@searchtype='LEGISLATION')">
@@ -128,7 +128,7 @@ Compiled:  2018-05-30T11:05:21.08+05:30-->
 
    <xsl:template match="bodytext[parent::level][$selectorID=('precedents','treatises','commentaryleghist')]">
       <xsl:choose>
-         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]"><!-- Revathi: Commented the below tags as this handling has been moved to precedents_level_Chof_comm.body.xsl to avoid validation errors --><!--<leg:levelbody xsl:exclude-result-prefixes="#all">
+         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('treatises','commentaryleghist')]"><!-- Revathi: Commented the below tags as this handling has been moved to precedents_level_Chof_comm.body.xsl to avoid validation errors --><!--<leg:levelbody xsl:exclude-result-prefixes="#all">
                     <leg:bodytext xsl:exclude-result-prefixes="#all">-->
             <xsl:apply-templates select="@* | node()"/>
             <!--</leg:bodytext>
@@ -592,8 +592,8 @@ Compiled:  2018-05-30T11:05:21.08+05:30-->
    </xsl:template>
 
    <xsl:template match="heading">
-      <xsl:choose>
-         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">
+      <xsl:choose><!-- Revathi: 30May2018 - Changed as per the clarification got from Awntika as legfragment element is not handled in rocket xslt, need to drop this change for precedents. --><!--<xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">-->
+         <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('treatises','commentaryleghist')]">
             <leg:heading xsl:exclude-result-prefixes="#all">
                <xsl:apply-templates select="@* | node()"/>
             </leg:heading>
@@ -687,9 +687,12 @@ Compiled:  2018-05-30T11:05:21.08+05:30-->
                             <xsl:otherwise>
                                 <xsl:value-of select="self::title/emph/emph[1]//text()"/>
                             </xsl:otherwise>
-                        </xsl:choose>--><!-- Revathi: Commented the above code and added the below to normalise the value -->
-                        <xsl:call-template name="Normalize_id_string">
-                           <xsl:with-param name="string" select="self::title/emph/emph[1]//text()"/>
+                        </xsl:choose>--><!-- Revathi: Commented the above code and added the below to normalise the value --><!-- Revathi: 29May2018 - (FOR 0PV8) Added the below variable to capture the desig content as the direct passing of parameter to the template "Normalize_id_string" was creating conflicts. -->
+                        <xsl:variable name="v_desig" as="xs:string">
+                           <xsl:value-of select="self::title/emph/emph[1]//text()"/>
+                        </xsl:variable>
+                        <xsl:call-template name="Normalize_id_string"><!--<xsl:with-param name="string" select="self::title/emph[1]//text()"/>-->
+                           <xsl:with-param name="string" select="$v_desig"/>
                         </xsl:call-template>
                      </xsl:attribute>
                      <designum xsl:exclude-result-prefixes="#all">
@@ -1480,6 +1483,7 @@ Compiled:  2018-05-30T11:05:21.08+05:30-->
          <xsl:when test="self::blockquote/child::*[1][name()='l'] and $selectorID = 'dictionary'">
             <xsl:apply-templates select="@* | node()"/>
          </xsl:when>
+         <!-- Revathi: 26May2018 - As suggested by Amita - Commented the below code as it is creating issues in rocket conversion. -->
          <!--<!-\-Dayanand singh 2018-05-02 updated in below when condition of parent::case:factsummary -\->
             <xsl:when test="self::blockquote[ancestor::case:appendix|parent::case:factsummary]/p/text/matches(text()[1],'^\(([a-z]+|[ivx]+)\)')[$selectorID = 'cases']">
                 <xsl:apply-templates/>

--- a/STREAM_SPECIFIC/precedents/precedents_bodytext_chof_level.xsl
+++ b/STREAM_SPECIFIC/precedents/precedents_bodytext_chof_level.xsl
@@ -5,7 +5,7 @@
 
     <xsl:template match="bodytext[parent::level][$selectorID=('precedents','treatises','commentaryleghist')]">
         <xsl:choose>
-            <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('precedents','treatises','commentaryleghist')]">
+            <xsl:when test="ancestor::level/child::heading/@searchtype='LEGISLATION'[$selectorID=('treatises','commentaryleghist')]">
                 <!-- Revathi: Commented the below tags as this handling has been moved to precedents_level_Chof_comm.body.xsl to avoid validation errors -->
                 <!--<leg:levelbody xsl:exclude-result-prefixes="#all">
                     <leg:bodytext xsl:exclude-result-prefixes="#all">-->

--- a/STREAM_SPECIFIC/precedents/precedents_level_Chof_comm.body.xsl
+++ b/STREAM_SPECIFIC/precedents/precedents_level_Chof_comm.body.xsl
@@ -23,7 +23,8 @@
         </xsl:variable>
         <!-- Revathi: Whenever the level is having heading/@searchtype as LEGISLATION, then we need to create level/bodytext/leg:level/leg:level-vrnt corresponding to the level in the input -->
         <xsl:choose>
-            <xsl:when test="self::level/heading/@searchtype='LEGISLATION'">
+            <!-- Revathi: 30May2018 - Changed as per the clarification got from Awntika as legfragment element is not handled in rocket xslt, need to drop this change for precedents. -->
+            <xsl:when test="self::level/heading/@searchtype='LEGISLATION' and not($selectorID = 'precedents')">
                 <xsl:choose>
                     <!-- Revathi: To check whether there are any ancestor level with @searchtype='LEGISLATION'.
                     If present, then should create leg:level/leg:level-vrnt only corresponding to the level in the input-->


### PR DESCRIPTION
Changes for precedents (removing legfragment and its child element creation) and update for treatises 0CWX and updated the cases monolithic.